### PR TITLE
Fixed value changing back with touch

### DIFF
--- a/PieSlice.cpp
+++ b/PieSlice.cpp
@@ -136,16 +136,17 @@ void PieSlice::mousePressEvent(QMouseEvent *event)
 
 
 void PieSlice::mouseMoveEvent(QMouseEvent *event)
-//void PieSlice::positionChanged(QMouseEvent *event)
 {
-    qreal eventAngle = angleAt(event->pos());
+    if (m_pressed)
+    {
+        qreal eventAngle = angleAt(event->pos());
 
-    emit moved(eventAngle - m_lastAngleMove);
-//    emit positionChanged(eventAngle - m_lastAngleMove);
-    m_lastAngleMove = eventAngle;
+        emit moved(eventAngle - m_lastAngleMove);
+        m_lastAngleMove = eventAngle;
+    }
 
 // I'm leaving this here for now as a little reminder of some things I'd like to implement later on,
-// like snaping and the position/angle update (which already happen right now but made on the javascript side)
+// like snaping and the position/angle update (which already happens right now but made on the javascript side)
 //
 //    const qreal oldPos = position;
 //    qreal pos = positionAt(point);

--- a/PieSlice.h
+++ b/PieSlice.h
@@ -52,7 +52,7 @@ protected:
     void mousePressEvent(QMouseEvent *event);
 //    void positionChanged(QMouseEvent *event);
     void mouseMoveEvent(QMouseEvent *event) override;
-    void mouseReleaseEvent(QMouseEvent *event);
+    void mouseReleaseEvent(QMouseEvent *event) override;
     void hoverEnterEvent(QHoverEvent *event);
     void hoverLeaveEvent(QHoverEvent *event);
     void mouseUngrabEvent();

--- a/Pomodoro.qml
+++ b/Pomodoro.qml
@@ -123,16 +123,8 @@ ApplicationWindow
                     color: containsMouse ? Qt.lighter(baseColor, 1.2) : baseColor
 
                     onClicked: button.clicked(event)
-                    onMoved:
-                    {
-                        lengthsPie.handleSlicesMove(slicePomodoroLength, deltaAngle)
-                        textLabel.text = Math.round(angleSpan / 6) + "min"
-                    }
-                    onReleased:
-                    {
-                        angleSpan = Math.round(angleSpan / 6) * 6
-                        textLabel.text = "start"
-                    }
+                    onMoved: lengthsPie.handleSlicesMove(slicePomodoroLength, deltaAngle)
+                    onReleased: textLabel.text = "start"
                 }
                 C.PieSlice
                 {
@@ -143,16 +135,8 @@ ApplicationWindow
                     angleSpan: 30
 
                     onClicked: button.clicked(event)
-                    onMoved:
-                    {
-                        lengthsPie.handleSlicesMove(sliceBreakLength, deltaAngle)
-                        textLabel.text = Math.round(angleSpan / 6) + "min"
-                    }
-                    onReleased:
-                    {
-                        angleSpan = Math.round(angleSpan / 6) * 6
-                        textLabel.text = "start"
-                    }
+                    onMoved: lengthsPie.handleSlicesMove(sliceBreakLength, deltaAngle)
+                    onReleased: textLabel.text = "start"
                 }
 
                 function handleSlicesMove(sourceElement, deltaAngle)


### PR DESCRIPTION
This pull request fixes an issue where when the user would drag the slice to change its value with a touch (instead of a mouse click) the value would change to arbitrary (or so it seems to me) values.

That happened because the mouseMove event is being called once again _after_ mouseRelease has happened.

